### PR TITLE
Update high contrast mode

### DIFF
--- a/src/components/contacts/ContactBox.astro
+++ b/src/components/contacts/ContactBox.astro
@@ -12,11 +12,11 @@ const props = Astro.props;
 ---
 
 <section
-  class="bg-surface mx-auto text-on-surface rounded max-w-90 h-90 p-8 pt-0 flex flex-col"
+  class="bg-surface relative z-1 mx-auto text-on-surface rounded max-w-90 h-90 p-8 pt-0 flex flex-col"
 >
   <div
     aria-hidden="true"
-    class="bg-avatar mx-auto text-on-avatar h-24 w-24 rounded-[50%] flex justify-center items-center -mt-12"
+    class="bg-avatar relative z-2 mx-auto text-on-avatar h-24 w-24 rounded-[50%] flex justify-center items-center -mt-12"
   >
     <slot name="icon" />
   </div>

--- a/src/components/footer/Footer.astro
+++ b/src/components/footer/Footer.astro
@@ -64,11 +64,12 @@ const iconSize = 16;
 
   html.high-contrast {
     #footer {
-      background-color: #ffffff;
-      color: #000000;
+      background-color: #000000;
+      color: #ffffff;
+      border-top: 3px solid white;
 
       svg {
-        fill: #000000;
+        fill: #ffffff;
       }
     }
   }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -34,9 +34,9 @@
   --_primary-hc: #ffd700;
   --_on-primary-hc: #000;
   --_primary-hover-hc: #84e2f1;
-  --_primary-active-hc: #ffffff;
-  --_surface-hc: #fff;
-  --_on-surface-hc: #000;
+  --_primary-active-hc: #ff00ff;
+  --_surface-hc: #000;
+  --_on-surface-hc: #fff;
   --_site-bg-hc: #000;
   --_on-site-bg-hc: #fff;
   --_outline-width-hc: 6px;
@@ -106,4 +106,12 @@ html.high-contrast {
 html.locked,
 html.locked body {
   overflow: hidden;
+}
+
+html.high-contrast .bg-surface {
+  outline: 3px solid white;
+}
+
+html.high-contrast .bg-chip-bg {
+  outline: 1px solid white;
 }


### PR DESCRIPTION
- The theme now uses only white text on black background, with sections being separated by white outlines instead
- Some parts had to be manually updated, especially if they used custom theming
- Some parts, like some technology graphics and button borders, don't necessarily have a huge contrast, but they do not affect the user experience as a whole