### PR TITLE
Close the drawer when going back

### DIFF
--- a/src/components/drawer/Drawer.astro
+++ b/src/components/drawer/Drawer.astro
@@ -28,6 +28,12 @@ const { class: className, side, ...props } = Astro.props;
     "dialog[data-drawer]"
   ) as NodeListOf<HTMLDialogElement>;
 
+  window.addEventListener("popstate", (e) => {
+    for (const dialog of dialogs) {
+      closeDialog(dialog);
+    }
+  });
+
   for (const dialog of dialogs) {
     dialog.addEventListener("click", (e) => {
       const target = e.target;

--- a/src/util/dialog/closeDialog.ts
+++ b/src/util/dialog/closeDialog.ts
@@ -7,6 +7,10 @@ export function closeDialog(target: HTMLDialogElement | string) {
 
   target.classList.add("close");
 
+  if (history.state?.dialogOpen) {
+    history.back();
+  }
+
   if (hasNotBlockedAnimations()) {
     setTimeout(() => {
       target.close();

--- a/src/util/dialog/openDialog.ts
+++ b/src/util/dialog/openDialog.ts
@@ -6,6 +6,8 @@ export function openDialog(dialogId: string) {
     ) as HTMLDialogElement;
     menu.showModal();
 
+    history.pushState({ dialogOpen: true }, '');
+
     requestAnimationFrame(() => {
       menu.classList.add("open");
       const html = document.querySelector("html")!;


### PR DESCRIPTION
Note: the implementation is slightly buggy when closing with Escape. Because the scripts don't hijack the process itself, it is possible for there to be "stale" history entries, causing the going back button to not go to a previous page (as the current page will have filled the history stack)